### PR TITLE
Fix #3

### DIFF
--- a/src/chartRenderer.ts
+++ b/src/chartRenderer.ts
@@ -66,11 +66,9 @@ export class ChartRenderer implements RendererConfig {
                     throw new Error('Issue with parsing config')
                 }
                 const configRecord = parsedConfig as Record<string, any>
-                if (!configRecord.dataset) {
-                    const dataset = [{ id: 'data', source: data }, ...(configRecord.dataset ?? [])]
-                    configRecord.dataset = dataset
-                }
-
+                const { dataset = [] } = configRecord
+                configRecord.dataset = [{ id: 'data', source: data }, ...dataset] 
+                
                 if (isRendered) {
                     // Data update
                     chart?.setOption(configRecord)

--- a/src/chartRenderer.ts
+++ b/src/chartRenderer.ts
@@ -67,7 +67,9 @@ export class ChartRenderer implements RendererConfig {
                 }
                 const configRecord = parsedConfig as Record<string, any>
                 const { dataset = [] } = configRecord
-                configRecord.dataset = [{ id: 'data', source: data }, ...dataset] 
+                if (dataset[0]?.id !== 'data') {
+                    configRecord.dataset = [{ id: 'data', source: data }, ...dataset] 
+                }
                 
                 if (isRendered) {
                     // Data update


### PR DESCRIPTION
Prepends SQL data to `dataset` even if user defines additional configs. Confirmed fixes #3 by adding https://github.com/texastoland/sql-seal-charts to [BRAT](https://obsidian.md/plugins?id=obsidian42-brat).

## Purpose

Adding a user dataset like:

```js
{ dataset: [...filters, ...sorts] }
```

disables the default SQL result and must be manually provided like:

```js
{ dataset: [{ source: data }, ...filters, ...sorts] }
```

and can be reproduced by adding `dataset: []` to any chart.

## Alternative

There's an argument to be made that injecting a dataset after the user overrides it is just as unexpected as not adding it. In that case the change should be:

```js
const configRecord = parsedConfig as Record<string, any>
configRecord.dataset ??= [{ id: 'data', source: data }]
```

## Chosen Solution

The DX question is the [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) (and inconvenience). My original use case was adding filters to a basic (JSON not JS) config. In that case I was surprised it didn't "just work".

On the other hand if the user intends to _replace_ (vs augment) SQL data (esp. in advanced mode) injecting would be inconvenient. By default additional datasets "pipe" from the first. In order to make it work they'd have to add `fromDatasetId` or `fromDatasetIndex` to each additional dataset (esp. for complex cases like histograms) to bypass the default.

But if advanced users explicitly name their dataset `id: 'data'` we won't override it. I plan to add documentation and a tutorial later 📓